### PR TITLE
Add README for s2i tasks and refactoring

### DIFF
--- a/s2i-dotnet1/README.md
+++ b/s2i-dotnet1/README.md
@@ -20,7 +20,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 
 ### Parameters
 
-* **VERSION**: Minor version of the .NET Core 1
+* **MINOR_VERSION**: Minor version of the .NET Core 1
   (_default: 1_)
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: ._)

--- a/s2i-dotnet1/README.md
+++ b/s2i-dotnet1/README.md
@@ -1,0 +1,96 @@
+# Dotnet1 Source-to-Image
+
+This task can be used for building `.NET1` Core apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This tasks uses the s2i-dotnet image build from [redhat-developer/s2i-dotnetcore](https://github.com/redhat-developer/s2i-dotnetcore).
+
+.NET1 Core versions currently provided are:
+
+- 1.0 (RHEL 7, CentOS 7)
+- 1.1 (RHEL 7)
+
+## Installing the Dotnet1 Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-dotnet1/s2i-dotnet1-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **VERSION**: Minor version of the .NET1
+  (_default: 1_)
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the Dotnet1 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a dotnet1 builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-dotnet1-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-dotnet1
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-dotnet1/README.md
+++ b/s2i-dotnet1/README.md
@@ -1,16 +1,16 @@
-# Dotnet1 Source-to-Image
+# .NET Core 1 Source-to-Image
 
-This task can be used for building `.NET1` Core apps as reproducible Docker 
+This task can be used for building `.NET Core 1` apps as reproducible Docker 
 images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
 is a toolkit and a workflow for building reproducible container images
 from source code. This tasks uses the s2i-dotnet image build from [redhat-developer/s2i-dotnetcore](https://github.com/redhat-developer/s2i-dotnetcore).
 
-.NET1 Core versions currently provided are:
+.NET Core versions currently provided are:
 
 - 1.0 (RHEL 7, CentOS 7)
 - 1.1 (RHEL 7)
 
-## Installing the Dotnet1 Task
+## Installing the .NET Core 1 Task
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-dotnet1/s2i-dotnet1-task.yaml
@@ -20,7 +20,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 
 ### Parameters
 
-* **VERSION**: Minor version of the .NET1
+* **VERSION**: Minor version of the .NET Core 1
   (_default: 1_)
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: ._)
@@ -64,8 +64,8 @@ oc adm policy add-role-to-user edit -z pipeline
 
 ## Creating the taskrun
 
-This TaskRun runs the Dotnet1 Task to fetch a Git repository and builds and 
-pushes a container image using S2I and a dotnet1 builder image.
+This TaskRun runs the .NET Core 1 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a .NET Core 1 builder image.
 
 ```
 apiVersion: tekton.dev/v1alpha1

--- a/s2i-dotnet1/s2i-dotnet1-task.yaml
+++ b/s2i-dotnet1/s2i-dotnet1-task.yaml
@@ -1,13 +1,16 @@
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
-  name: s2i-dotnet
+  name: s2i-dotnet1
 spec:
   inputs:
     resources:
       - name: source
         type: git
     params:
+      - name: VERSION
+        description: The minor version of the dotnet1
+        default: '1'
       - name: PATH_CONTEXT
         description: The location of the path to run s2i from.
         default: .
@@ -22,7 +25,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.centos.org/dotnet/dotnet-21-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/dotnet/dotnetcore-1${inputs.params.VERSION}-rhel7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source

--- a/s2i-dotnet1/s2i-dotnet1-task.yaml
+++ b/s2i-dotnet1/s2i-dotnet1-task.yaml
@@ -9,7 +9,7 @@ spec:
         type: git
     params:
       - name: VERSION
-        description: The minor version of the dotnet1
+        description: The minor version of the .NET Core 1
         default: '1'
       - name: PATH_CONTEXT
         description: The location of the path to run s2i from.

--- a/s2i-dotnet1/s2i-dotnet1-task.yaml
+++ b/s2i-dotnet1/s2i-dotnet1-task.yaml
@@ -8,7 +8,7 @@ spec:
       - name: source
         type: git
     params:
-      - name: VERSION
+      - name: MINOR_VERSION
         description: The minor version of the .NET Core 1
         default: '1'
       - name: PATH_CONTEXT
@@ -25,7 +25,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/dotnet/dotnetcore-1${inputs.params.VERSION}-rhel7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/dotnet/dotnetcore-1${inputs.params.MINOR_VERSION}-rhel7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source

--- a/s2i-dotnet2/README.md
+++ b/s2i-dotnet2/README.md
@@ -20,7 +20,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 
 ### Parameters
 
-* **VERSION**: Minor version of the ,NET Core 2
+* **MINOR_VERSION**: Minor version of the ,NET Core 2
   (_default: 2_)
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: ._)

--- a/s2i-dotnet2/README.md
+++ b/s2i-dotnet2/README.md
@@ -1,16 +1,16 @@
-# Dotnet2 Source-to-Image
+# .NET Core 2 Source-to-Image
 
-This task can be used for building `.NET2` Core apps as reproducible Docker 
+This task can be used for building `.NET Core 2` apps as reproducible Docker 
 images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
 is a toolkit and a workflow for building reproducible container images
 from source code. This tasks uses the s2i-dotnet image build from [redhat-developer/s2i-dotnetcore](https://github.com/redhat-developer/s2i-dotnetcore).
 
-.NET2 Core versions currently provided are:
+.NET Core versions currently provided are:
 
 - 2.1 (RHEL 7, RHEL 8, CentOS 7)
 - 2.2 (RHEL 7, CentOS 7)
 
-## Installing the Dotnet2 Task
+## Installing the .NET Core 2 Task
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-dotnet2/s2i-dotnet2-task.yaml
@@ -20,7 +20,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 
 ### Parameters
 
-* **VERSION**: Minor version of the ,NET 2
+* **VERSION**: Minor version of the ,NET Core 2
   (_default: 2_)
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: ._)
@@ -64,8 +64,8 @@ oc adm policy add-role-to-user edit -z pipeline
 
 ## Creating the taskrun
 
-This TaskRun runs the Dotnet2 Task to fetch a Git repository and builds and 
-pushes a container image using S2I and a dotnet2 builder image.
+This TaskRun runs the .NET Core 2 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a .NET Core 2 builder image.
 
 ```
 apiVersion: tekton.dev/v1alpha1

--- a/s2i-dotnet2/README.md
+++ b/s2i-dotnet2/README.md
@@ -1,0 +1,96 @@
+# Dotnet2 Source-to-Image
+
+This task can be used for building `.NET2` Core apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This tasks uses the s2i-dotnet image build from [redhat-developer/s2i-dotnetcore](https://github.com/redhat-developer/s2i-dotnetcore).
+
+.NET2 Core versions currently provided are:
+
+- 2.1 (RHEL 7, RHEL 8, CentOS 7)
+- 2.2 (RHEL 7, CentOS 7)
+
+## Installing the Dotnet2 Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-dotnet2/s2i-dotnet2-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **VERSION**: Minor version of the ,NET 2
+  (_default: 2_)
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the Dotnet2 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a dotnet2 builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-dotnet2-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-dotnet2
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-dotnet2/s2i-dotnet2-task.yaml
+++ b/s2i-dotnet2/s2i-dotnet2-task.yaml
@@ -9,7 +9,7 @@ spec:
         type: git
     params:
       - name: VERSION
-        description: The minor version of the dotnet2
+        description: The minor version of the .NET Core 2
         default: '2'
       - name: PATH_CONTEXT
         description: The location of the path to run s2i from.

--- a/s2i-dotnet2/s2i-dotnet2-task.yaml
+++ b/s2i-dotnet2/s2i-dotnet2-task.yaml
@@ -8,7 +8,7 @@ spec:
       - name: source
         type: git
     params:
-      - name: VERSION
+      - name: MINOR_VERSION
         description: The minor version of the .NET Core 2
         default: '2'
       - name: PATH_CONTEXT
@@ -25,7 +25,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.centos.org/dotnet/dotnet-2${inputs.params.VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.centos.org/dotnet/dotnet-2${inputs.params.MINOR_VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source

--- a/s2i-dotnet2/s2i-dotnet2-task.yaml
+++ b/s2i-dotnet2/s2i-dotnet2-task.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: s2i-dotnet2
+spec:
+  inputs:
+    resources:
+      - name: source
+        type: git
+    params:
+      - name: VERSION
+        description: The minor version of the dotnet2
+        default: '2'
+      - name: PATH_CONTEXT
+        description: The location of the path to run s2i from.
+        default: .
+      - name: TLSVERIFY
+        description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+        default: "true"
+  outputs:
+    resources:
+      - name: image
+        type: image
+  steps:
+    - name: generate
+      image: quay.io/openshift-pipeline/s2i
+      workingdir: /workspace/source
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.centos.org/dotnet/dotnet-2${inputs.params.VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      volumeMounts:
+        - name: gen-source
+          mountPath: /gen-source
+    - name: build
+      image: quay.io/buildah/stable
+      workingdir: /gen-source
+      command: ['buildah', 'bud', '--tls-verify=${inputs.params.TLSVERIFY}', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '${outputs.resources.image.url}', '.']
+      volumeMounts:
+        - name: varlibcontainers
+          mountPath: /var/lib/containers
+        - name: gen-source
+          mountPath: /gen-source
+      securityContext:
+        privileged: true
+    - name: push
+      image: quay.io/buildah/stable
+      command: ['buildah', 'push', '--tls-verify=${inputs.params.TLSVERIFY}', '${outputs.resources.image.url}', 'docker://${outputs.resources.image.url}']
+      volumeMounts:
+        - name: varlibcontainers
+          mountPath: /var/lib/containers
+      securityContext:
+        privileged: true
+  volumes:
+    - name: varlibcontainers
+      emptyDir: {}
+    - name: gen-source
+      emptyDir: {}

--- a/s2i-go/README.md
+++ b/s2i-go/README.md
@@ -1,0 +1,93 @@
+# Go Source-to-Image
+
+This task can be used for building `GO` apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This tasks uses the s2i-go image build from [sclorg/golang-container](https://github.com/sclorg/golang-container).
+
+GO versions currently provided are:
+
+- 1.10
+
+## Installing the Go Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-go/s2i-go-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the Go Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a Go builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-go-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-go
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-java11/README.md
+++ b/s2i-java11/README.md
@@ -1,11 +1,11 @@
-# Java11 Source-to-Image
+# Java 11 Source-to-Image
 
-This task can be used for building `Java11` apps as reproducible Docker 
+This task can be used for building `Java 11` apps as reproducible Docker 
 images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
 is a toolkit and a workflow for building reproducible container images
-from source code. This java11 task uses `registry.access.redhat.com/openjdk/openjdk-11-rhel7` builder image
+from source code. This java 11 task uses `registry.access.redhat.com/openjdk/openjdk-11-rhel7` builder image
 
-## Installing the Java11 Task
+## Installing the Java 11 Task
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-java11/s2i-java-11-task.yaml
@@ -57,8 +57,8 @@ oc adm policy add-role-to-user edit -z pipeline
 
 ## Creating the taskrun
 
-This TaskRun runs the java11 Task to fetch a Git repository and builds and 
-pushes a container image using S2I and a Java11 builder image.
+This TaskRun runs the java 11 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a Java 11 builder image.
 
 ```
 apiVersion: tekton.dev/v1alpha1

--- a/s2i-java11/README.md
+++ b/s2i-java11/README.md
@@ -1,0 +1,89 @@
+# Java11 Source-to-Image
+
+This task can be used for building `Java11` apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This java11 task uses `registry.access.redhat.com/openjdk/openjdk-11-rhel7` builder image
+
+## Installing the Java11 Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-java11/s2i-java-11-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the java11 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a Java11 builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-java11-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-java-11
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-java8/README.md
+++ b/s2i-java8/README.md
@@ -1,13 +1,13 @@
-# Java8 Source-to-Image
+# Java 8 Source-to-Image
 
-This task can be used for building `Java8` apps as reproducible Docker 
+This task can be used for building `Java 8` apps as reproducible Docker 
 images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
 is a toolkit and a workflow for building reproducible container images
-from source code. This java8 task uses `registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift` builder image
+from source code. This java 8 task uses `registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift` builder image
 
 The current version of the Java S2I builder image supports OpenJDK 1.8, Jolokia 1.3.5, and Maven 3.3.9-2.8
 
-## Installing the Java8 Task
+## Installing the Java 8 Task
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-java8/s2i-java-8-task.yaml
@@ -59,8 +59,8 @@ oc adm policy add-role-to-user edit -z pipeline
 
 ## Creating the taskrun
 
-This TaskRun runs the java8 Task to fetch a Git repository and builds and 
-pushes a container image using S2I and a Java8 builder image.
+This TaskRun runs the java 8 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a Java 8 builder image.
 
 ```
 apiVersion: tekton.dev/v1alpha1

--- a/s2i-java8/README.md
+++ b/s2i-java8/README.md
@@ -1,0 +1,91 @@
+# Java8 Source-to-Image
+
+This task can be used for building `Java8` apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This java8 task uses `registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift` builder image
+
+The current version of the Java S2I builder image supports OpenJDK 1.8, Jolokia 1.3.5, and Maven 3.3.9-2.8
+
+## Installing the Java8 Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-java8/s2i-java-8-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the java8 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a Java8 builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-java8-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-java-8
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-nodejs/README.md
+++ b/s2i-nodejs/README.md
@@ -1,0 +1,97 @@
+# Nodejs Source-to-Image
+
+This task can be used for building `Nodejs` apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This tasks uses the s2i-nodejs image build from [sclorg/s2i-nodejs-container](https://github.com/sclorg/s2i-nodejs-container).
+
+Node.JS versions currently provided are:
+
+- NodeJS 6
+- NodeJS 8
+- NodeJS 10
+
+## Installing the Nodejs Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-nodejs/s2i-nodejs-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **VERSION**: Version of the Nodejs
+  (_default: 10_)
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the Nodejs Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a nodejs builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-nodejs-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-nodejs
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-perl/README.md
+++ b/s2i-perl/README.md
@@ -20,7 +20,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 
 ### Parameters
 
-* **VERSION**: Minor version of the Perl5
+* **MINOR_VERSION**: Minor version of the Perl5
   (_default: 26_)
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: ._)

--- a/s2i-perl/README.md
+++ b/s2i-perl/README.md
@@ -1,0 +1,96 @@
+# Perl Source-to-Image
+
+This task can be used for building `Perl` apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This tasks uses the s2i-perl image build from [sclorg/s2i-perl-container](https://github.com/sclorg/s2i-perl-container).
+
+Perl versions currently provided are:
+
+- Perl 5.24
+- Perl 5.26
+
+## Installing the Perl Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-perl/s2i-perl-5-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **VERSION**: Minor version of the Perl5
+  (_default: 26_)
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the perl Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a perl builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-perl-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-perl
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-perl/s2i-perl-5-task.yaml
+++ b/s2i-perl/s2i-perl-5-task.yaml
@@ -8,7 +8,7 @@ spec:
       - name: source
         type: git
     params:
-      - name: VERSION
+      - name: MINOR_VERSION
         description: The minor version of the perl
         default: '26'
       - name: PATH_CONTEXT
@@ -25,7 +25,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/perl-5${inputs.params.VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/perl-5${inputs.params.MINOR_VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source

--- a/s2i-php/README.md
+++ b/s2i-php/README.md
@@ -1,0 +1,97 @@
+# PHP Source-to-Image
+
+This task can be used for building `PHP` apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This tasks uses the s2i-php image build from [sclorg/s2i-php-container](https://github.com/sclorg/s2i-php-container).
+
+PHP versions currently provided are:
+
+- PHP 7.0
+- PHP 7.1
+- PHP 7.2
+
+## Installing the PHP Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-php/s2i-php-7-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **VERSION**: Minor version of the PHP 7
+  (_default: 2_)
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the php Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a php builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-php-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-php
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-php/README.md
+++ b/s2i-php/README.md
@@ -21,7 +21,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 
 ### Parameters
 
-* **VERSION**: Minor version of the PHP 7
+* **MINOR_VERSION**: Minor version of the PHP 7
   (_default: 2_)
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: ._)

--- a/s2i-php/s2i-php-7-task.yaml
+++ b/s2i-php/s2i-php-7-task.yaml
@@ -8,7 +8,7 @@ spec:
       - name: source
         type: git
     params:
-      - name: VERSION
+      - name: MINOR_VERSION
         description: The minor version of the php
         default: '2'
       - name: PATH_CONTEXT
@@ -25,7 +25,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/php-7${inputs.params.VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/php-7${inputs.params.MINOR_VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source

--- a/s2i-python2/README.md
+++ b/s2i-python2/README.md
@@ -1,11 +1,11 @@
-# Python2 Source-to-Image
+# Python 2 Source-to-Image
 
 This task can be used for building `Python` apps as reproducible Docker 
 images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
 is a toolkit and a workflow for building reproducible container images
 from source code. This tasks uses the s2i-python image build from [sclorg/s2i-python-container](https://github.com/sclorg/s2i-python-container).
 
-Python2 versions currently provided are:
+Python 2 versions currently provided are:
 
 - Python 2.7
 
@@ -63,8 +63,8 @@ oc adm policy add-role-to-user edit -z pipeline
 
 ## Creating the taskrun
 
-This TaskRun runs the python2 Task to fetch a Git repository and builds and 
-pushes a container image using S2I and a python2 builder image.
+This TaskRun runs the python 2 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a python 2 builder image.
 
 ```
 apiVersion: tekton.dev/v1alpha1

--- a/s2i-python2/README.md
+++ b/s2i-python2/README.md
@@ -1,0 +1,95 @@
+# Python2 Source-to-Image
+
+This task can be used for building `Python` apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This tasks uses the s2i-python image build from [sclorg/s2i-python-container](https://github.com/sclorg/s2i-python-container).
+
+Python2 versions currently provided are:
+
+- Python 2.7
+
+## Installing the Python Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-python2/s2i-python-2-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **VERSION**: Minor version of the Python 2
+  (_default: 7_)
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the python2 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a python2 builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-python2-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-python-2
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-python2/README.md
+++ b/s2i-python2/README.md
@@ -19,7 +19,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 
 ### Parameters
 
-* **VERSION**: Minor version of the Python 2
+* **MINOR_VERSION**: Minor version of the Python 2
   (_default: 7_)
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: ._)

--- a/s2i-python2/s2i-python-2-task.yaml
+++ b/s2i-python2/s2i-python-2-task.yaml
@@ -8,7 +8,7 @@ spec:
       - name: source
         type: git
     params:
-      - name: VERSION
+      - name: MINOR_VERSION
         description: The minor version of the python 2
         default: '7'
       - name: PATH_CONTEXT
@@ -25,7 +25,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/python-2${inputs.params.VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/python-2${inputs.params.MINOR_VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source

--- a/s2i-python2/s2i-python-2-task.yaml
+++ b/s2i-python2/s2i-python-2-task.yaml
@@ -9,7 +9,7 @@ spec:
         type: git
     params:
       - name: VERSION
-        description: The minor version of the python2
+        description: The minor version of the python 2
         default: '7'
       - name: PATH_CONTEXT
         description: The location of the path to run s2i from.

--- a/s2i-python3/README.md
+++ b/s2i-python3/README.md
@@ -1,11 +1,11 @@
-# Python3 Source-to-Image
+# Python 3 Source-to-Image
 
 This task can be used for building `Python` apps as reproducible Docker 
 images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
 is a toolkit and a workflow for building reproducible container images
 from source code. This tasks uses the s2i-python image build from [sclorg/s2i-python-container](https://github.com/sclorg/s2i-python-container).
 
-Python3 versions currently provided are:
+Python 3 versions currently provided are:
 
 - Python 3.5
 - Python 3.6
@@ -65,8 +65,8 @@ oc adm policy add-role-to-user edit -z pipeline
 
 ## Creating the taskrun
 
-This TaskRun runs the python3 Task to fetch a Git repository and builds and 
-pushes a container image using S2I and a python3 builder image.
+This TaskRun runs the python 3 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a python 3 builder image.
 
 ```
 apiVersion: tekton.dev/v1alpha1

--- a/s2i-python3/README.md
+++ b/s2i-python3/README.md
@@ -21,7 +21,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 
 ### Parameters
 
-* **VERSION**: Minor version of the Python 3
+* **MINOR_VERSION**: Minor version of the Python 3
   (_default: 6_)
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: ._)

--- a/s2i-python3/README.md
+++ b/s2i-python3/README.md
@@ -1,0 +1,97 @@
+# Python3 Source-to-Image
+
+This task can be used for building `Python` apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This tasks uses the s2i-python image build from [sclorg/s2i-python-container](https://github.com/sclorg/s2i-python-container).
+
+Python3 versions currently provided are:
+
+- Python 3.5
+- Python 3.6
+- Python 3.7
+
+## Installing the Python Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-python3/s2i-python-3-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **VERSION**: Minor version of the Python 3
+  (_default: 6_)
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the python3 Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a python3 builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-python3-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-python-3
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-python3/s2i-python-3-task.yaml
+++ b/s2i-python3/s2i-python-3-task.yaml
@@ -9,7 +9,7 @@ spec:
         type: git
     params:
       - name: VERSION
-        description: The minor version of the python3
+        description: The minor version of the python 3
         default: '6'
       - name: PATH_CONTEXT
         description: The location of the path to run s2i from.

--- a/s2i-python3/s2i-python-3-task.yaml
+++ b/s2i-python3/s2i-python-3-task.yaml
@@ -8,7 +8,7 @@ spec:
       - name: source
         type: git
     params:
-      - name: VERSION
+      - name: MINOR_VERSION
         description: The minor version of the python 3
         default: '6'
       - name: PATH_CONTEXT
@@ -25,7 +25,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/python-3${inputs.params.VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/python-3${inputs.params.MINOR_VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source

--- a/s2i-ruby/README.md
+++ b/s2i-ruby/README.md
@@ -1,0 +1,97 @@
+# Ruby Source-to-Image
+
+This task can be used for building `Ruby` apps as reproducible Docker 
+images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and a workflow for building reproducible container images
+from source code. This tasks uses the s2i-ruby image build from [sclorg/s2i-ruby-container](https://github.com/sclorg/s2i-ruby-container).
+
+Ruby versions currently provided are:
+
+- Ruby 2.3
+- Ruby 2.4
+- Ruby 2.5
+
+## Installing the Ruby Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/s2i-ruby/s2i-ruby-2-task.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **VERSION**: Minor version of the Ruby 2
+  (_default: 5_)
+* **PATH_CONTEXT**: Source path from where S2I command needs to be run
+  (_default: ._)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
+## Creating a ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. The image needs proper credentials to be 
+authenticated by the remote container registry. These credentials can 
+be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you run on OpenShift, you also need to allow the service
+account to run privileged containers. Due to security considerations 
+OpenShift does not allow containers to run as privileged containers 
+by default.
+
+Run the following in order to create a service account named
+`pipelines` on OpenShift and allow it to run privileged containers:
+
+```
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Creating the taskrun
+
+This TaskRun runs the ruby Task to fetch a Git repository and builds and 
+pushes a container image using S2I and a ruby builder image.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: s2i-ruby-taskrun
+spec:
+  # Use service account with git and image repo credentials
+  serviceAccount: pipeline
+  taskRef:
+    name: s2i-ruby
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/username/reponame
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: quay.io/my-repo/my-image-name
+```

--- a/s2i-ruby/README.md
+++ b/s2i-ruby/README.md
@@ -21,7 +21,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 
 ### Parameters
 
-* **VERSION**: Minor version of the Ruby 2
+* **MINOR_VERSION**: Minor version of the Ruby 2
   (_default: 5_)
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: ._)

--- a/s2i-ruby/s2i-ruby-2-task.yaml
+++ b/s2i-ruby/s2i-ruby-2-task.yaml
@@ -8,7 +8,7 @@ spec:
       - name: source
         type: git
     params:
-      - name: VERSION
+      - name: MINOR_VERSION
         description: The minor version of the ruby
         default: '5'
       - name: PATH_CONTEXT
@@ -25,7 +25,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/ruby-2${inputs.params.VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'centos/ruby-2${inputs.params.MINOR_VERSION}-centos7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source


### PR DESCRIPTION
This will add readme for the s2i tasks
available.

Also refactored a bit to separate
dotnet1 and dotnet2 tasks