### PR TITLE
Update nodejs version in task yaml

### DIFF
--- a/s2i-nodejs/s2i-nodejs-task.yaml
+++ b/s2i-nodejs/s2i-nodejs-task.yaml
@@ -10,7 +10,7 @@ spec:
     params:
       - name: VERSION
         description: The version of the nodejs
-        default: '10'
+        default: '8'
       - name: PATH_CONTEXT
         description: The location of the path to run s2i from.
         default: .


### PR DESCRIPTION
Update nodejs version default value in yaml
because of the image with version 10 is not available
with the same name.

This remained by mistake in #10 where we changed the
README but forgot to change yaml.