### PR TITLE
Make `MAVEN_ARGS_APPEND` and `MAVEN_MIRROR_URL` optional params

### DIFF
--- a/s2i-java-11/README.md
+++ b/s2i-java-11/README.md
@@ -19,11 +19,11 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
   (_default: `.`_)
 * **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
   non-TLS registry) (_default:_ `true`)
+* **MAVEN_ARGS_APPEND**: Additional Maven arguments (_required_, _no default_)
 * **MAVEN_CLEAR_REPO**: Remove the Maven repository after the artifact is 
   built (_default:_ `false`)
-* **MAVEN_ARGS_APPEND**: Additional Maven arguments (_default:_ `Empty String`)
 * **MAVEN_MIRROR_URL**: The base URL of a mirror used for retrieving artifacts 
-  (_default:_ `http://repo.maven.apache.org/maven2`)
+  ((_required_, _no default_))
 
 
 ### Resources

--- a/s2i-java-11/README.md
+++ b/s2i-java-11/README.md
@@ -16,9 +16,14 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 ### Parameters
 
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
-  (_default: ._)
+  (_default: `.`_)
 * **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
   non-TLS registry) (_default:_ `true`)
+* **MAVEN_CLEAR_REPO**: Remove the Maven repository after the artifact is 
+  built (_default:_ `false`)
+* **MAVEN_ARGS_APPEND**: Additional Maven arguments (_default:_ `Empty String`)
+* **MAVEN_MIRROR_URL**: The base URL of a mirror used for retrieving artifacts 
+  (_default:_ `http://repo.maven.apache.org/maven2`)
 
 
 ### Resources

--- a/s2i-java-11/s2i-java-11-task.yaml
+++ b/s2i-java-11/s2i-java-11-task.yaml
@@ -9,11 +9,20 @@ spec:
         type: git
     params:
       - name: PATH_CONTEXT
-        description: The location of the path to run s2i from.
+        description: The location of the path to run s2i from
         default: .
       - name: TLSVERIFY
         description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
         default: "true"
+      - name: MAVEN_CLEAR_REPO
+        description: Remove the Maven repository after the artifact is built
+        default: "false"
+      - name: MAVEN_ARGS_APPEND
+        description: Additional Maven arguments
+        default: ""
+      - name: MAVEN_MIRROR_URL
+        description: The base URL of a mirror used for retrieving artifacts
+        default: "http://repo.maven.apache.org/maven2"
   outputs:
     resources:
       - name: image
@@ -22,7 +31,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/openjdk/openjdk-11-rhel7', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/openjdk/openjdk-11-rhel7', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', '-e', 'MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}', '-e', 'MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source

--- a/s2i-java-11/s2i-java-11-task.yaml
+++ b/s2i-java-11/s2i-java-11-task.yaml
@@ -28,42 +28,43 @@ spec:
       - name: image
         type: image
   steps:
-    - name: filter-args
+    - name: gen-env-file
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /filter-args
+      workingdir: /env-params
       command:
         - '/bin/sh'
         - '-c'
       args:
-        - ARG="" &&
-          if [[ $(inputs.params.MAVEN_ARGS_APPEND) != "skip-if-not-set" ]]; then
-          ARG="-e MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}";
+        - echo "MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}" > env-file &&
+          if [[ ${inputs.params.MAVEN_ARGS_APPEND} != "skip-if-not-set" ]]; then
+            echo "MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}" >> env-file;
           fi &&
-          if [[ $(inputs.params.MAVEN_MIRROR_URL) != "skip-if-not-set" ]]; then
-          ARG="$ARG -e MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}";
+          if [[ ${inputs.params.MAVEN_MIRROR_URL} != "skip-if-not-set" ]]; then
+            echo "MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}" >> env-file;
           fi &&
-          echo "$ARG" | tee optional-args
+          cat env-file
       volumeMounts:
-        - name: vfilterargs
-          mountPath: /filter-args
+        - name: envparams
+          mountPath: /env-params
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      #command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/openjdk/openjdk-11-rhel7', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', '-e', 'MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}', '-e', 'MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}']
       command:
-      - 's2i'
-      - 'build'
-      - '${inputs.params.PATH_CONTEXT}'
-      - 'registry.access.redhat.com/openjdk/openjdk-11-rhel7'
-      - '--image-scripts-url image:///usr/local/s2i'
-      - '--as-dockerfile /gen-source/Dockerfile.gen'
-      - '-e MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}'
-      - "$(cat /filter-args/optional-args"
+        - 's2i'
+        - 'build'
+        - '${inputs.params.PATH_CONTEXT}'
+        - 'registry.access.redhat.com/openjdk/openjdk-11-rhel7'
+        - '--image-scripts-url'
+        - 'image:///usr/local/s2i'
+        - '--as-dockerfile'
+        - '/gen-source/Dockerfile.gen'
+        - '--environment-file'
+        - '/env-params/env-file'
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
-        - name: vfilterargs
-          mountPath: /filter-args
+        - name: envparams
+          mountPath: /env-params
     - name: build
       image: quay.io/buildah/stable
       workingdir: /gen-source
@@ -88,5 +89,5 @@ spec:
       emptyDir: {}
     - name: gen-source
       emptyDir: {}
-    - name: vfilterargs
+    - name: envparams
       emptyDir: {}

--- a/s2i-java-11/s2i-java-11-task.yaml
+++ b/s2i-java-11/s2i-java-11-task.yaml
@@ -14,27 +14,56 @@ spec:
       - name: TLSVERIFY
         description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
         default: "true"
+      - name: MAVEN_ARGS_APPEND
+        description: Additional Maven arguments
+        default: "skip-if-not-set"
       - name: MAVEN_CLEAR_REPO
         description: Remove the Maven repository after the artifact is built
         default: "false"
-      - name: MAVEN_ARGS_APPEND
-        description: Additional Maven arguments
-        default: ""
       - name: MAVEN_MIRROR_URL
         description: The base URL of a mirror used for retrieving artifacts
-        default: "http://repo.maven.apache.org/maven2"
+        default: "skip-if-not-set"
   outputs:
     resources:
       - name: image
         type: image
   steps:
+    - name: filter-args
+      image: quay.io/openshift-pipeline/s2i
+      workingdir: /filter-args
+      command:
+        - '/bin/sh'
+        - '-c'
+      args:
+        - ARG="" &&
+          if [[ $(inputs.params.MAVEN_ARGS_APPEND) != "skip-if-not-set" ]]; then
+          ARG="-e MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}";
+          fi &&
+          if [[ $(inputs.params.MAVEN_MIRROR_URL) != "skip-if-not-set" ]]; then
+          ARG="$ARG -e MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}";
+          fi &&
+          echo "$ARG" | tee optional-args
+      volumeMounts:
+        - name: vfilterargs
+          mountPath: /filter-args
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/openjdk/openjdk-11-rhel7', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', '-e', 'MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}', '-e', 'MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}']
+      #command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/openjdk/openjdk-11-rhel7', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', '-e', 'MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}', '-e', 'MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}']
+      command:
+      - 's2i'
+      - 'build'
+      - '${inputs.params.PATH_CONTEXT}'
+      - 'registry.access.redhat.com/openjdk/openjdk-11-rhel7'
+      - '--image-scripts-url image:///usr/local/s2i'
+      - '--as-dockerfile /gen-source/Dockerfile.gen'
+      - '-e MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}'
+      - "$(cat /filter-args/optional-args"
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
+        - name: vfilterargs
+          mountPath: /filter-args
     - name: build
       image: quay.io/buildah/stable
       workingdir: /gen-source
@@ -58,4 +87,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
     - name: gen-source
+      emptyDir: {}
+    - name: vfilterargs
       emptyDir: {}

--- a/s2i-java-8/README.md
+++ b/s2i-java-8/README.md
@@ -18,9 +18,14 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 ### Parameters
 
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
-  (_default: ._)
+  (_default: `.`_)
 * **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
   non-TLS registry) (_default:_ `true`)
+* **MAVEN_CLEAR_REPO**: Remove the Maven repository after the artifact is 
+  built (_default:_ `false`)
+* **MAVEN_ARGS_APPEND**: Additional Maven arguments (_default:_ `Empty String`)
+* **MAVEN_MIRROR_URL**: The base URL of a mirror used for retrieving artifacts 
+  (_default:_ `http://repo.maven.apache.org/maven2`)
 
 
 ### Resources

--- a/s2i-java-8/README.md
+++ b/s2i-java-8/README.md
@@ -21,11 +21,11 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
   (_default: `.`_)
 * **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
   non-TLS registry) (_default:_ `true`)
+* **MAVEN_ARGS_APPEND**: Additional Maven arguments (_required_, _no default_)
 * **MAVEN_CLEAR_REPO**: Remove the Maven repository after the artifact is 
   built (_default:_ `false`)
-* **MAVEN_ARGS_APPEND**: Additional Maven arguments (_default:_ `Empty String`)
 * **MAVEN_MIRROR_URL**: The base URL of a mirror used for retrieving artifacts 
-  (_default:_ `http://repo.maven.apache.org/maven2`)
+  ((_required_, _no default_))
 
 
 ### Resources

--- a/s2i-java-8/s2i-java-8-task.yaml
+++ b/s2i-java-8/s2i-java-8-task.yaml
@@ -28,40 +28,43 @@ spec:
       - name: image
         type: image
   steps:
-    - name: filter-args
+    - name: gen-env-file
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /filter-args
+      workingdir: /env-params
       command:
         - '/bin/sh'
         - '-c'
       args:
-        - ARG="" &&
-          if [[ $(inputs.params.MAVEN_ARGS_APPEND) != "skip-if-not-set" ]]; then
-          ARG="-e MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}";
+        - echo "MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}" > env-file &&
+          if [[ ${inputs.params.MAVEN_ARGS_APPEND} != "skip-if-not-set" ]]; then
+            echo "MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}" >> env-file;
           fi &&
-          if [[ $(inputs.params.MAVEN_MIRROR_URL) != "skip-if-not-set" ]]; then
-          ARG="$ARG -e MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}";
+          if [[ ${inputs.params.MAVEN_MIRROR_URL} != "skip-if-not-set" ]]; then
+            echo "MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}" >> env-file;
           fi &&
-          echo "$ARG" | tee optional-args
+          cat env-file
       volumeMounts:
-        - name: vfilterargs
-          mountPath: /filter-args
+        - name: envparams
+          mountPath: /env-params
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      #command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', xxXXX]command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', xxXXX]
       command:
-      - 's2i'
-      - 'build'
-      - '${inputs.params.PATH_CONTEXT}'
-      - 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift'
-      - '--image-scripts-url image:///usr/local/s2i'
-      - '--as-dockerfile /gen-source/Dockerfile.gen'
-      - '-e MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}'
-      - "$(cat /filter-args/optional-args"
+        - 's2i'
+        - 'build'
+        - '${inputs.params.PATH_CONTEXT}'
+        - 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift'
+        - '--image-scripts-url'
+        - 'image:///usr/local/s2i'
+        - '--as-dockerfile'
+        - '/gen-source/Dockerfile.gen'
+        - '--environment-file'
+        - '/env-params/env-file'
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
+        - name: envparams
+          mountPath: /env-params
     - name: build
       image: quay.io/buildah/stable
       workingdir: /gen-source
@@ -71,8 +74,6 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-        - name: vfilterargs
-          mountPath: /filter-args
       securityContext:
         privileged: true
     - name: push
@@ -88,5 +89,5 @@ spec:
       emptyDir: {}
     - name: gen-source
       emptyDir: {}
-    - name: vfilterargs
+    - name: envparams
       emptyDir: {}

--- a/s2i-java-8/s2i-java-8-task.yaml
+++ b/s2i-java-8/s2i-java-8-task.yaml
@@ -9,11 +9,20 @@ spec:
         type: git
     params:
       - name: PATH_CONTEXT
-        description: The location of the path to run s2i from.
+        description: The location of the path to run s2i from
         default: .
       - name: TLSVERIFY
         description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
         default: "true"
+      - name: MAVEN_CLEAR_REPO
+        description: Remove the Maven repository after the artifact is built
+        default: "false"
+      - name: MAVEN_ARGS_APPEND
+        description: Additional Maven arguments
+        default: ""
+      - name: MAVEN_MIRROR_URL
+        description: The base URL of a mirror used for retrieving artifacts
+        default: "http://repo.maven.apache.org/maven2"
   outputs:
     resources:
       - name: image
@@ -22,7 +31,7 @@ spec:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen']
+      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', '-e', 'MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}', '-e', 'MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source

--- a/s2i-java-8/s2i-java-8-task.yaml
+++ b/s2i-java-8/s2i-java-8-task.yaml
@@ -14,24 +14,51 @@ spec:
       - name: TLSVERIFY
         description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
         default: "true"
+      - name: MAVEN_ARGS_APPEND
+        description: Additional Maven arguments
+        default: "skip-if-not-set"
       - name: MAVEN_CLEAR_REPO
         description: Remove the Maven repository after the artifact is built
         default: "false"
-      - name: MAVEN_ARGS_APPEND
-        description: Additional Maven arguments
-        default: ""
       - name: MAVEN_MIRROR_URL
         description: The base URL of a mirror used for retrieving artifacts
-        default: "http://repo.maven.apache.org/maven2"
+        default: "skip-if-not-set"
   outputs:
     resources:
       - name: image
         type: image
   steps:
+    - name: filter-args
+      image: quay.io/openshift-pipeline/s2i
+      workingdir: /filter-args
+      command:
+        - '/bin/sh'
+        - '-c'
+      args:
+        - ARG="" &&
+          if [[ $(inputs.params.MAVEN_ARGS_APPEND) != "skip-if-not-set" ]]; then
+          ARG="-e MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}";
+          fi &&
+          if [[ $(inputs.params.MAVEN_MIRROR_URL) != "skip-if-not-set" ]]; then
+          ARG="$ARG -e MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}";
+          fi &&
+          echo "$ARG" | tee optional-args
+      volumeMounts:
+        - name: vfilterargs
+          mountPath: /filter-args
     - name: generate
       image: quay.io/openshift-pipeline/s2i
       workingdir: /workspace/source
-      command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', '-e', 'MAVEN_ARGS_APPEND=${inputs.params.MAVEN_ARGS_APPEND}', '-e', 'MAVEN_MIRROR_URL=${inputs.params.MAVEN_MIRROR_URL}']
+      #command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', xxXXX]command: ['s2i', 'build', '${inputs.params.PATH_CONTEXT}', 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift', '--image-scripts-url', 'image:///usr/local/s2i', '--as-dockerfile', '/gen-source/Dockerfile.gen', '-e', 'MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}', xxXXX]
+      command:
+      - 's2i'
+      - 'build'
+      - '${inputs.params.PATH_CONTEXT}'
+      - 'registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift'
+      - '--image-scripts-url image:///usr/local/s2i'
+      - '--as-dockerfile /gen-source/Dockerfile.gen'
+      - '-e MAVEN_CLEAR_REPO=${inputs.params.MAVEN_CLEAR_REPO}'
+      - "$(cat /filter-args/optional-args"
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
@@ -44,6 +71,8 @@ spec:
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
+        - name: vfilterargs
+          mountPath: /filter-args
       securityContext:
         privileged: true
     - name: push
@@ -58,4 +87,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
     - name: gen-source
+      emptyDir: {}
+    - name: vfilterargs
       emptyDir: {}


### PR DESCRIPTION
Update Task ParamSpec for s2i-java tasks

Add three more parameters for Java s2i tasks
- MAVEN_CLEAR_REPO
- MAVEN_ARGS_APPEND
- MAVEN_MIRROR_URL

Make `MAVEN_ARGS_APPEND` and `MAVEN_MIRROR_URL` optional (no default)

Add an additional step in the `s2i-java` tasks to filter out optional
params when they are not explicitly specified

Add `----environment-file` flag instead of `-e` flags
Add mechanism to conditionaly collect environment variables in a file
and pass that file to `s2i` as `--environment-file`

### s2i-java-8 sample log (from pipeline-tutorial pipelinerun)

#### param spec in pipelinerun
```
params:
      - name: TLSVERIFY
        value: "false"
      - name: MAVEN_ARGS_APPEND
        value: "val-MAVEN_ARGS_APPEND"
      - name: MAVEN_CLEAR_REPO
        value: "true"
```
#### pipelinerun log
```
[build : gen-env-file] MAVEN_CLEAR_REPO=true
[build : gen-env-file] MAVEN_ARGS_APPEND=val-MAVEN_ARGS_APPEND
...
build : build] d409e616bb458113e97094ce47a7ea57ca0d8ff2a6b104c4f91b263499d3a0f2
[build : build] STEP 3: ENV MAVEN_CLEAR_REPO="true"     MAVEN_ARGS_APPEND="val-MAVEN_ARGS_APPEND"
```

Cherry-Pick Previous work down by Piyush: https://github.com/openshift/pipelines-catalog/pull/12