### PR TITLE
Change spring petclinic to fork

### DIFF
--- a/task/s2i-java-11-workspace/0.1/tests/run.yaml
+++ b/task/s2i-java-11-workspace/0.1/tests/run.yaml
@@ -15,13 +15,11 @@ spec:
           workspace: shared-workspace
       params:
         - name: url
-          value: https://github.com/spring-projects/spring-petclinic
+          value: https://github.com/piyush-garg/spring-petclinic
         - name: subdirectory
           value: ""
         - name: deleteExisting
           value: "true"
-        - name: revision
-          value: "d367e2b4b41a2de899b0f438bc984a7c1c011b77"
     - name: s2i-java-11-test
       taskRef:
         name: s2i-java-11-workspace

--- a/task/s2i-java-11/0.1/tests/resources.yaml
+++ b/task/s2i-java-11/0.1/tests/resources.yaml
@@ -6,10 +6,8 @@ metadata:
 spec:
   type: git
   params:
-    - name: revision
-      value: "d367e2b4b41a2de899b0f438bc984a7c1c011b77"
     - name: url
-      value: https://github.com/spring-projects/spring-petclinic
+      value: https://github.com/piyush-garg/spring-petclinic
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource


### PR DESCRIPTION
This will change spring-petclinic example to
fork as it is not working with java11 and
fork has one dependency change