### PR TITLE
s2i-eap: migrate task to v1beta1 API

### DIFF
--- a/task/s2i-eap/0.1/README.md
+++ b/task/s2i-eap/0.1/README.md
@@ -1,6 +1,6 @@
 # Java EAP Source-to-Image
 
-This task can be used for building `Java EAP` apps as reproducible Docker 
+This task can be used for building `Java EAP` apps as reproducible Docker
 images using Source-to-Image. [Source-to-Image (S2I)](https://github.com/openshift/source-to-image) is a toolkit and a workflow for building reproducible container images from source code. This java eap task uses `registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8` builder image.
 
 This current version of the Java EAP S2I builder image supports OpenJDK 11, EAP CD 18, and Maven 3.5.4-5.
@@ -11,29 +11,22 @@ This current version of the Java EAP S2I builder image supports OpenJDK 11, EAP 
 kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/task/s2i-eap/0.1/s2i-eap.yaml
 ```
 
-## Inputs
-
 ## Parameters
 
 * **PATH_CONTEXT**: Source path from where S2I command needs to be run
   (_default: `.`_)
 * **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry) (_default:_ `true`)
 
-
 ## Resources
+
+### Inputs
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the source to build.
 
-## Volumes
-This task requires a ConfigMap called `s2i-eap-configmap` with a file called `env-file` and the following variables defined in it:
+### Outputs
 
-* **MAVEN_ARGS_APPEND**: Additional Maven arguments (_optional_, _no default_)
-* **MAVEN_CLEAR_REPO**: Remove the Maven repository after the artifact is 
-  built (_default:_ `false`)
-* **MAVEN_MIRROR_URL**: The base URL of a mirror used for retrieving artifacts 
-  (_optional_, _no default_)
-* **GALLEON_PROVISION_LAYERS**: Comma separated list of Galleon layers to provision a server (_optional_, _no default_)
-* **GALLEON_PROVISION_DEFAULT_FAT_SERVER**: (_set to true_)
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
 
 Example:
 ```
@@ -47,24 +40,17 @@ data:
     GALLEON_PROVISION_DEFAULT_FAT_SERVER=true
 ```
 
-## Outputs
-
-### Resources
-
-* **image**: An `image`-type `PipelineResource` specifying the image that should
-  be built.
-
 ## Creating a ServiceAccount
 
 S2I builds an image and pushes it to the destination registry which is
-defined as a parameter. The image needs proper credentials to be 
-authenticated by the remote container registry. These credentials can 
+defined as a parameter. The image needs proper credentials to be
+authenticated by the remote container registry. These credentials can
 be provided through a serviceaccount. See [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
 for further details.
 
 If you run on OpenShift, you also need to allow the service
-account to run privileged containers. Due to security considerations 
-OpenShift does not allow containers to run as privileged containers 
+account to run privileged containers. Due to security considerations
+OpenShift does not allow containers to run as privileged containers
 by default.
 
 Run the following in order to create a service account named
@@ -94,7 +80,7 @@ oc secrets link pipeline <pull_secret_name>
 This TaskRun runs the java EAP Task to fetch a Git repository and builds and pushes a container image using S2I and a Java EAP builder image. It is an example based on an existing BuildConfig of EAP:
 
 ```
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: s2i-eap-taskrun
@@ -103,13 +89,13 @@ spec:
   serviceAccountName: pipeline
   taskRef:
     name: s2i-eap
-  inputs:
-    params:
-    - name: PATH_CONTEXT
-      value: kitchensink
-    - name: TLSVERIFY
-      value: 'false'
-    resources:
+  params:
+  - name: PATH_CONTEXT
+    value: kitchensink
+  - name: TLSVERIFY
+    value: 'false'
+  resources:
+    inputs:
     - name: source
       resourceSpec:
         type: git
@@ -118,8 +104,7 @@ spec:
           value: https://github.com/jboss-developer/jboss-eap-quickstarts
         - name: revision
           value: openshift
-  outputs:
-    resources:
+    outputs:
     - name: image
       resourceSpec:
         type: image

--- a/task/s2i-eap/0.1/s2i-eap.yaml
+++ b/task/s2i-eap/0.1/s2i-eap.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: s2i-eap
@@ -16,21 +16,20 @@ spec:
     This current version of the Java EAP S2I builder image supports
     OpenJDK 11, EAP CD 18, and Maven 3.5.4-5.
 
-  inputs:
-    resources:
+  params:
+    - name: PATH_CONTEXT
+      description: The location of the path to run s2i from
+      default: .
+      type: string
+    - name: TLSVERIFY
+      description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+      default: "true"
+      type: string
+  resources:
+    inputs:
       - name: source
         type: git
-    params:
-      - name: PATH_CONTEXT
-        description: The location of the path to run s2i from
-        default: .
-        type: string
-      - name: TLSVERIFY
-        description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
-        default: "true"
-        type: string
-  outputs:
-    resources:
+    outputs:
       - name: image
         type: image
   stepTemplate:
@@ -44,7 +43,7 @@ spec:
       command:
         - 's2i'
         - 'build'
-        - '$(inputs.params.PATH_CONTEXT)'
+        - '$(params.PATH_CONTEXT)'
         - 'registry.redhat.io/jboss-eap-7-tech-preview/eap-cd-openshift-rhel8'
         - '--assemble-user'
         - '185'
@@ -62,7 +61,7 @@ spec:
     - name: build
       image: quay.io/buildah/stable:v1.11.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
+      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
@@ -72,7 +71,7 @@ spec:
         privileged: true
     - name: push
       image: quay.io/buildah/stable:v1.11.0
-      command: ['buildah', 'push', '--tls-verify=$(inputs.params.TLSVERIFY)', '$(outputs.resources.image.url)', 'docker://$(outputs.resources.image.url)']
+      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers


### PR DESCRIPTION
This updates s2i-eap task to v1beta1 API.
See https://issues.redhat.com/browse/SRVKP-836

/cc @savitaashture @sthaha @piyush-garg 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>