### PR TITLE
removes STORAGE_DRIVER from Env

### DIFF
--- a/task/buildah-pr/0.1/README.md
+++ b/task/buildah-pr/0.1/README.md
@@ -18,7 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/openshift/pipelines-catalog/m
 ### Parameters
 
 * **BUILDER_IMAGE:**: The name of the image containing the Buildah tool. See
-  note below.  (_default:_ quay.io/buildah/stable:v1.15.1)
+  note below.  (_default:_ quay.io/buildah/stable:v1.17.0)
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
 * **CONTEXT**: Path to the directory to use as context (_default:_

--- a/task/buildah-pr/0.1/buildah-pr.yaml
+++ b/task/buildah-pr/0.1/buildah-pr.yaml
@@ -22,7 +22,7 @@ spec:
   params:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: quay.io/buildah/stable:v1.15.1
+      default: quay.io/buildah/stable:v1.17.0
     - name: DOCKERFILE
       description: Path to the Dockerfile to build.
       default: ./Dockerfile
@@ -47,23 +47,17 @@ spec:
     - name: build
       image: $(params.BUILDER_IMAGE)
       workingDir: /workspace/source
-      command: ['buildah', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(resources.outputs.image.url)', '$(params.CONTEXT)']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(resources.outputs.image.url)', '$(params.CONTEXT)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
       image: $(params.BUILDER_IMAGE)
       workingDir: /workspace/source
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-dotnet-1-pr/0.1/s2i-dotnet-1-pr.yaml
+++ b/task/s2i-dotnet-1-pr/0.1/s2i-dotnet-1-pr.yaml
@@ -42,26 +42,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-dotnet-1/0.1/s2i-dotnet-1.yaml
+++ b/task/s2i-dotnet-1/0.1/s2i-dotnet-1.yaml
@@ -41,26 +41,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-dotnet-2-pr/0.1/s2i-dotnet-2-pr.yaml
+++ b/task/s2i-dotnet-2-pr/0.1/s2i-dotnet-2-pr.yaml
@@ -42,26 +42,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-dotnet-2/0.1/s2i-dotnet-2.yaml
+++ b/task/s2i-dotnet-2/0.1/s2i-dotnet-2.yaml
@@ -41,26 +41,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-dotnet-3-pr/0.1/s2i-dotnet-3-pr.yaml
+++ b/task/s2i-dotnet-3-pr/0.1/s2i-dotnet-3-pr.yaml
@@ -42,26 +42,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-dotnet-3/0.1/s2i-dotnet-3.yaml
+++ b/task/s2i-dotnet-3/0.1/s2i-dotnet-3.yaml
@@ -41,26 +41,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-eap-pr/0.1/s2i-eap-pr.yaml
+++ b/task/s2i-eap-pr/0.1/s2i-eap-pr.yaml
@@ -59,26 +59,20 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-eap/0.1/s2i-eap.yaml
+++ b/task/s2i-eap/0.1/s2i-eap.yaml
@@ -59,26 +59,20 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-go-pr/0.1/s2i-go-pr.yaml
+++ b/task/s2i-go-pr/0.1/s2i-go-pr.yaml
@@ -38,26 +38,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-go/0.1/s2i-go.yaml
+++ b/task/s2i-go/0.1/s2i-go.yaml
@@ -37,26 +37,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-java-11-pr/0.1/s2i-java-11-pr.yaml
+++ b/task/s2i-java-11-pr/0.1/s2i-java-11-pr.yaml
@@ -85,26 +85,20 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-java-11/0.1/s2i-java-11.yaml
+++ b/task/s2i-java-11/0.1/s2i-java-11.yaml
@@ -84,26 +84,20 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-java-8-pr/0.1/s2i-java-8-pr.yaml
+++ b/task/s2i-java-8-pr/0.1/s2i-java-8-pr.yaml
@@ -85,26 +85,20 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-java-8/0.1/s2i-java-8.yaml
+++ b/task/s2i-java-8/0.1/s2i-java-8.yaml
@@ -84,26 +84,20 @@ spec:
         - name: envparams
           mountPath: /env-params
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-nodejs-pr/0.1/s2i-nodejs-pr.yaml
+++ b/task/s2i-nodejs-pr/0.1/s2i-nodejs-pr.yaml
@@ -42,26 +42,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -41,26 +41,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-perl-pr/0.1/s2i-perl-pr.yaml
+++ b/task/s2i-perl-pr/0.1/s2i-perl-pr.yaml
@@ -42,26 +42,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-perl/0.1/s2i-perl.yaml
+++ b/task/s2i-perl/0.1/s2i-perl.yaml
@@ -41,26 +41,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-php-pr/0.1/s2i-php-pr.yaml
+++ b/task/s2i-php-pr/0.1/s2i-php-pr.yaml
@@ -42,26 +42,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-php/0.1/s2i-php.yaml
+++ b/task/s2i-php/0.1/s2i-php.yaml
@@ -41,26 +41,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-python-2-pr/0.1/s2i-python-2-pr.yaml
+++ b/task/s2i-python-2-pr/0.1/s2i-python-2-pr.yaml
@@ -42,26 +42,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-python-2/0.1/s2i-python-2.yaml
+++ b/task/s2i-python-2/0.1/s2i-python-2.yaml
@@ -41,26 +41,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-python-3-pr/0.1/s2i-python-3-pr.yaml
+++ b/task/s2i-python-3-pr/0.1/s2i-python-3-pr.yaml
@@ -42,26 +42,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-python-3/0.1/s2i-python-3.yaml
+++ b/task/s2i-python-3/0.1/s2i-python-3.yaml
@@ -41,26 +41,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-ruby-pr/0.1/s2i-ruby-pr.yaml
+++ b/task/s2i-ruby-pr/0.1/s2i-ruby-pr.yaml
@@ -42,26 +42,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(resources.outputs.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}

--- a/task/s2i-ruby/0.1/s2i-ruby.yaml
+++ b/task/s2i-ruby/0.1/s2i-ruby.yaml
@@ -41,26 +41,20 @@ spec:
         - name: gen-source
           mountPath: /gen-source
     - name: build
-      image: quay.io/buildah/stable:v1.15.1
+      image: quay.io/buildah/stable:v1.17.0
       workingdir: /gen-source
-      command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
+      command: ['buildah', 'bud', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(params.IMAGE)', '.']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
         - name: gen-source
           mountPath: /gen-source
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
     - name: push
-      image: quay.io/buildah/stable:v1.15.1
-      command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+      image: quay.io/buildah/stable:v1.17.0
+      command: ['buildah', 'push', '--storage-driver=vfs', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
       volumeMounts:
         - name: varlibcontainers
           mountPath: /var/lib/containers
-      env:
-      - name: STORAGE_DRIVER
-        value: vfs
   volumes:
     - name: varlibcontainers
       emptyDir: {}


### PR DESCRIPTION
this removes STORAGE_DRIVER from Env variables and put as
parameter` --storage-driver=vfs` form in the buildah command

this was observed that even after putting STORAGE_DRIVER vfs
as Env the default value was set overlay

ref :
      https://github.com/containers/storage/pull/797
      https://github.com/tektoncd/operator/pull/200