### PR TITLE
Add nightly CI update script and pipeline 

### DIFF
--- a/openshift/release/nightly-ci-run.yaml
+++ b/openshift/release/nightly-ci-run.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipelines-catalog-nightly
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: source
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source
+        params:
+          - name: url
+            value: https://github.com/openshift/pipelines-catalog
+          - name: revision
+            value: master
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: create-pr
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - workspace: source
+            name: source
+        taskSpec:
+          workspaces:
+          - name: source
+          steps:
+            - name: create-pr
+              workingDir: $(workspaces.source.path)
+              env:
+                - name: HUB_VERSION
+                  value: "true"
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: nightly-ci-github-hub-token
+                      key: hub-token              
+              image: gcr.io/tekton-releases/dogfooding/hub:latest
+              script: |
+                #!/usr/bin/env bash
+                set -xe
+
+                # Configure git email and name
+                git config user.email "pipelines-dev@redhat.com"
+                git config user.name "OpenShift Pipelines"
+                
+                ## Make sure we can push to the branch with our GITHUB_TOKEN (disable logging to not leak)
+                set +x
+                git remote set-url origin $(git remote get-url origin|sed "s,https://github.com/,https://${GITHUB_TOKEN}@github.com/,")
+                set -x
+                # Launch script
+                openshift/release/update-to-head.sh
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Synchs the release-next branch to master and then triggers CI
+# Usage: update-to-head.sh
+
+set -e
+set -x
+REPO_NAME=`basename $(git remote get-url origin)`
+BRANCH=${BRANCH:-master}
+LABEL=nightly-ci
+
+# Reset release-next to upstream/master.
+git fetch origin ${BRANCH}
+git checkout origin/${BRANCH} --no-track -B release-next
+
+git push -f origin HEAD:release-next
+
+# Trigger CI
+git checkout release-next --no-track -B release-next-ci
+date > ci
+git add ci
+git commit -m "Tekton as a code triggered CI on branch 'release-next' after synching to upstream/master"
+
+git push -f origin HEAD:release-next-ci
+
+already_open_github_issue_id=$(hub pr list -s open -f "%I %l%n"|grep ${LABEL}| awk '{print $1}'|head -1)
+[[ -n ${already_open_github_issue_id} ]]  && {
+    echo "PR for nightly is already open on #${already_open_github_issue_id} sending a /retest"
+    hub api repos/openshift/${REPO_NAME}/issues/${already_open_github_issue_id}/comments -f body='/retest'
+    exit
+}
+
+hub pull-request -m "🛑🔥 Triggering Nightly CI for ${REPO_NAME} 🔥🛑" -m "/hold" -m "Nightly CI do not merge :stop_sign:" \
+    --no-edit -l "${LABEL}" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci


### PR DESCRIPTION
Add nightly CI update-to-head script which is modified of what we do on the other forks and a pipeline to execute it.

This is meant to be launched nightly via a cron

PR that get created example: https://github.com/openshift/pipelines-catalog/pull/74
