### PR TITLE
Add cronjob for nightly pipelines catalog

### DIFF
--- a/openshift/release/cron-nightly-ci-run.yaml
+++ b/openshift/release/cron-nightly-ci-run.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: pipelines-catalog-nightly-ci-run
+spec:
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: tkn-aac-sa
+          containers:
+          - name: cleanup
+            image: quay.io/openshift/origin-cli:4.6
+            command: ["/bin/bash", "-c", "kubectl delete pipelinerun pipelines-catalog-nightly || true;kubectl create -f https://raw.githubusercontent.com/openshift/pipelines-catalog/master/openshift/release/nightly-ci-run.yaml"]
+          restartPolicy: Never


### PR DESCRIPTION
The almost final piece tested :

The cron runs at midnight UTC and outputs this : 


![image](https://user-images.githubusercontent.com/98980/106007332-79e07680-60b6-11eb-828c-e0669359fcec.png)

The pipelinerun that was just created will launch [openshift/release/update-to-head.sh](./openshift/release/update-to-head.sh) which update release-next with master and release-next-ci for PR, detect if there is one already open  PR with the nightly-CI label and then issue a /retest or create a new pull-request if there wasn't : 

![image](https://user-images.githubusercontent.com/98980/106007386-88c72900-60b6-11eb-8c79-54c22e9f68f9.png)

And the pipeline nightly would run : 

![image](https://user-images.githubusercontent.com/98980/106007455-9c728f80-60b6-11eb-88fa-7c88af3e8e7c.png)

and shows in Slack #tekton-pipelines-ci :

![image](https://user-images.githubusercontent.com/98980/106010749-17897500-60ba-11eb-838a-5ffd8ce26c6e.png)
