### PR TITLE
Revert "update version to same as osp 1.4.0"

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: s2i-dotnet
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, dotnet, workspace
@@ -89,7 +89,7 @@ kind: Task
 metadata:
   name: s2i-go
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, go, workspace
@@ -174,7 +174,7 @@ kind: Task
 metadata:
   name: s2i-java
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, java, workspace
@@ -308,7 +308,7 @@ kind: Task
 metadata:
   name: s2i-nodejs
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, nodejs, workspace
@@ -393,7 +393,7 @@ kind: Task
 metadata:
   name: s2i-php
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, php, workspace
@@ -478,7 +478,7 @@ kind: Task
 metadata:
   name: s2i-python
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, python, workspace
@@ -565,7 +565,7 @@ kind: Task
 metadata:
   name: s2i-ruby
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, ruby, workspace

--- a/task/s2i-dotnet/0.1/s2i-dotnet.yaml
+++ b/task/s2i-dotnet/0.1/s2i-dotnet.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: s2i-dotnet
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, dotnet, workspace

--- a/task/s2i-eap/0.1/s2i-eap.yaml
+++ b/task/s2i-eap/0.1/s2i-eap.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: s2i-eap
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, eap

--- a/task/s2i-go/0.1/s2i-go.yaml
+++ b/task/s2i-go/0.1/s2i-go.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: s2i-go
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, go, workspace

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: s2i-java
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, java, workspace

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: s2i-nodejs
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, nodejs, workspace

--- a/task/s2i-perl/0.1/s2i-perl.yaml
+++ b/task/s2i-perl/0.1/s2i-perl.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: s2i-perl
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, perl, workspace

--- a/task/s2i-php/0.1/s2i-php.yaml
+++ b/task/s2i-php/0.1/s2i-php.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: s2i-php
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, php, workspace

--- a/task/s2i-python/0.1/s2i-python.yaml
+++ b/task/s2i-python/0.1/s2i-python.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: s2i-python
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, python, workspace

--- a/task/s2i-ruby/0.1/s2i-ruby.yaml
+++ b/task/s2i-ruby/0.1/s2i-ruby.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: s2i-ruby
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, ruby, workspace


### PR DESCRIPTION
This reverts commit d840709c98bb8a8abbac98ab006f0beb262b5266.

This is to make catalog not violates the proposal and now onwards
we will bump the task version accordingly whenever there is a
breaking or backward incompatible change