### PR TITLE
Fix volumemount issue

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -2390,7 +2390,7 @@ spec:
               yamllint .tekton/ task/
 
     - name: kubectl-dry-run
-      runAfter: [fetch]
+      runAfter: [yaml-lint]
       taskSpec:
         workspaces:
           - name: source
@@ -2406,7 +2406,7 @@ spec:
           workspace: source
 
     - name: check-generated-yaml
-      runAfter: [fetch]
+      runAfter: [kubectl-dry-run]
       workspaces:
         - name: source
           workspace: source

--- a/openshift/gen/prestep.yaml
+++ b/openshift/gen/prestep.yaml
@@ -29,7 +29,7 @@
           yamllint .tekton/ task/
 
 - name: kubectl-dry-run
-  runAfter: [fetch]
+  runAfter: [yaml-lint]
   taskSpec:
     workspaces:
       - name: source
@@ -45,7 +45,7 @@
       workspace: source
 
 - name: check-generated-yaml
-  runAfter: [fetch]
+  runAfter: [kubectl-dry-run]
   workspaces:
     - name: source
       workspace: source


### PR DESCRIPTION
We were getting this :

```
Warning  FailedAttachVolume  8m4s                   attachdetach-controller  Multi-Attach error for volume "pvc-56c166ce-d8e4-4df2-a683-7ca4f7f9c7fb" Volume is already used by pod(s) pipelines-catalog-run-yaml-lint-jrjnk-pod-q6ftc
  Warning  FailedAttachVolume  4m25s (x3 over 6m31s)  attachdetach-controller  AttachVolume.Attach failed for volume "pvc-56c166ce-d8e4-4df2-a683-7ca4f7f9c7fb" : Volume "f2c71679-31d8-4ace-8ff7-081966d659a9" failed to be attached within the alloted time
```

Let's make sure each runs after each other