### PR TITLE
Remove prerun to anyuid from CI since we don't need it anymore with 1.3.x

### DIFF
--- a/.tekton/tekton.yaml
+++ b/.tekton/tekton.yaml
@@ -1,9 +1,6 @@
 owners:
   - "@openshift-pipelines"
 
-prerun:
-  - oc adm policy add-scc-to-user anyuid system:serviceaccount:{{namespace}}:pipeline
-
 tasks:
   - git-clone
 


### PR DESCRIPTION
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
