### PR TITLE
Add deprecation and redirection notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# ⚠️ ⚠ ️⚠️ Warning ⚠️ ⚠️ ⚠️
+
+This repository is deprecated.
+
+🧑‍💻 Development and maitenence of these tasks have moved to:
+https://github.com/tektoncd/operator/tree/main/cmd/openshift/operator/kodata/tekton-addon/addons/02-clustertasks/source_local
+
+The tasks in this repository are not maintained anymore.
+
+--- 
+
 # Pipelines Catalog
 
 This repository contains a catalog of Tekton `Task` resources (and


### PR DESCRIPTION
Add a prominent message in README.md to indicate that the maitenance of the
tasks in this repository has moved to tektoncd/operator

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>